### PR TITLE
fix: hover color for download button

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -43,9 +43,9 @@ export default () => {
             <NavItem>
               <NavLink href="/modules">Modules</NavLink>
             </NavItem>
-            <NavItem className="download-btn">
+            <NavItem className="font-weight-bold btn btn-sm btn-success download-btn">
               <NavLink
-                className="btn btn-primary btn-download"
+                className="text-white"
                 href="https://github.com/MovingBlocks/TerasologyLauncher/releases/latest/download/TerasologyLauncher.zip"
               >
                 <IconContext.Provider

--- a/src/layout/css/_buttons.scss
+++ b/src/layout/css/_buttons.scss
@@ -20,3 +20,7 @@
 .btn-primary:focus {
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05), 0 1px 5px 0 rgba(0, 0, 0, 0.1) !important;
 }
+
+.download-btn {
+  margin-left: 0.5em;
+}

--- a/src/layout/css/_header.scss
+++ b/src/layout/css/_header.scss
@@ -16,10 +16,6 @@ nav {
   margin: 0.125em;
 }
 
-.btn-download {
-  font-size: 1.6rem;
-}
-
 .download {
   margin-right: 0.5em;
 }
@@ -29,10 +25,6 @@ nav {
 .slideIn {
   -webkit-animation-name: slideIn;
   animation-name: slideIn;
-}
-
-.download-btn {
-  margin-left: 0.5em;
 }
 
 .dropdown-item {


### PR DESCRIPTION
This commit addresses the issue of  bright download button.
While also removing extra classes and refactoring the CSS
file.

Before hover: 
![image](https://user-images.githubusercontent.com/49101492/107848515-fd6dc780-6e19-11eb-93fc-62c88a178e28.png)

After hover: 
![image](https://user-images.githubusercontent.com/49101492/107848523-10809780-6e1a-11eb-9838-6b5fa3241d81.png)

