### PR TITLE
fix: remove bootstrap style from history title

### DIFF
--- a/src/components/About/About.jsx
+++ b/src/components/About/About.jsx
@@ -68,7 +68,7 @@ export default props => {
                   alt="Terasology History" />
               </Col>
               <Col lg="7">
-                <h3 className="mb-3 text-right mr-4">History</h3>
+                <h3 className="mb-3 mr-4">History</h3>
                 <p className="text-justify">
                 Founded in 2011 by Benjamin "Begla" Glatzel while researching procedural terrain generation and effective 
                 rendering techniques, He succeded in creating a minecraft like demo


### PR DESCRIPTION
fixes #38 
## before:
![image](https://user-images.githubusercontent.com/43696525/108250996-eeba4400-717c-11eb-8d35-281ddce32e49.png)


## after: 
![image](https://user-images.githubusercontent.com/43696525/108250908-d64a2980-717c-11eb-8160-1392499739de.png)

