### PR TITLE
feat: add git hooks to format files pre commit

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Fixes git index after commit
+# Issue: https://github.com/prettier/prettier/issues/2978#issuecomment-334408427
+git update-index -g

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Fetch added, copied, modified and renamed files
+FILES=$(git diff --cached --name-only --diff-filter=ACMR "*.js" "*.jsx" "*.scss" "*.css" "*.json" | sed 's| |\\ |g')
+[ -z "$FILES" ] && echo "No files were changed." && exit 0
+
+# Prettify all selected files
+echo "$FILES" | xargs ./node_modules/.bin/prettier --write
+
+# Check if an error occurred while formatting the files
+if [ $? -eq 0 ];
+then
+  # Add back the modified/prettified files to staging
+  echo "$FILES" | xargs git add
+  exit 0
+else
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "lint:js": "eslint --ext .js,.jsx .",
     "lint:md": "remark content/posts/",
     "write-good": "write-good $(glob 'content/posts/**/*.md')",
-    "format:js": "prettier '**/*.{js,jsx}' --write"
+    "format:js": "prettier '**/*.{js,jsx}' --write",
+    "postinstall": "./scripts/setup-git-hooks"
   },
   "remarkConfig": {
     "plugins": [

--- a/scripts/setup-git-hooks
+++ b/scripts/setup-git-hooks
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Check if git is 2.9 or greater
+# Only git 2.9 and greater supports `cor.hooksPath`
+if (echo a version 2.9.0; git --version) | sort -Vk3 | tail -1 | grep -q git
+then
+  git config core.hooksPath .githooks
+else
+  find .git/hooks -type l -exec rm {} \;
+  find .githooks -type f -exec ln -sf ../../{} .git/hooks/ \;
+fi


### PR DESCRIPTION
Added execution of `Prettier` on every commit reducing manual workload.

**How to test:**
- ~Setup git hooks by executing `./scripts/setup-git-hooks`~
- Hooks now setup automatically as yarn `postInstall` lifecycle
- Make some changes to a file
- Track and commit the file