### PR TITLE
fix: mentor page customField references

### DIFF
--- a/src/components/Mentor/Mentor.jsx
+++ b/src/components/Mentor/Mentor.jsx
@@ -69,8 +69,7 @@ const Mentor = () => {
                   break;
               }
             }
-            const flagURL =
-              `https://flagcdn.com/w40/${mentorCountry.toLowerCase()}.png`;
+            const flagURL = `https://flagcdn.com/w40/${mentorCountry.toLowerCase()}.png`;
 
             const timeZone = moment
               .tz(moment(), `${mentorTimezone}`)

--- a/src/components/Mentor/Mentor.jsx
+++ b/src/components/Mentor/Mentor.jsx
@@ -51,21 +51,36 @@ const Mentor = () => {
       <Row className="justify-content-center">
         {mentors &&
           mentors.map(mentor => {
-            let flagURL =
-              "https://www.countryflags.io/" +
-              `${mentor.customFieldItems[0].value.text}` +
-              "/flat/64.png";
+            let mentorGitHubName = "";
+            let mentorCountry = "";
+            let mentorTimezone = "";
+            for (let i = 0; i < 3; i++) {
+              switch(mentor.customFieldItems[i].idCustomField) {
+                case "5eb71b3551de3a59ce8d9bd8":
+                  mentorGitHubName = mentor.customFieldItems[i].value.text;
+                  break;
+                case "5eb71b7081a67c3b58ea67ed":
+                  mentorCountry = mentor.customFieldItems[i].value.text;
+                  break;
+                case "5eb71b53f52d88487f550e83":
+                  mentorTimezone = mentor.customFieldItems[i].value.text;
+                  break;
+                default:
+                  break;
+              }
+            }
+            const flagURL =
+              "https://www.countryflagsapi.com/png/" + `${mentorCountry}`;
 
-            let timeZone = moment
-              .tz(moment(), `${mentor.customFieldItems[1].value.text}`)
+            const timeZone = moment
+              .tz(moment(), `${mentorTimezone}`)
               .format("HH:mm [(GMT] Z[)]");
 
             let getcountryName = new Intl.DisplayNames(["en"], {
               type: "region"
             });
-            let countryName = getcountryName.of(
-              `${mentor.customFieldItems[0].value.text}`
-            );
+            const countryName = getcountryName.of(`${mentorCountry}`);
+
             return (
               <Col className="ml-1 mr-1 mt-2 mb-2" lg="3" md="8" sm="12">
                 <div class="card border border-0 row_shadow">
@@ -98,7 +113,7 @@ const Mentor = () => {
                         <p className="font-weight-bold">{mentor.name}</p>
 
                         <div className="mt-2">
-                          <img src={flagURL} height="30px" width="30px"></img>
+                          <img src={flagURL} height="30px" width="30px" alt="The flag of the mentor's home country"></img>
                           <span className="ml-3 font-weight-bold h4">
                             {countryName}
                           </span>
@@ -114,7 +129,7 @@ const Mentor = () => {
                             name={mentor.name}
                             desc={mentor.desc}
                             tags={mentor.labels}
-                            customInfo={mentor.customFieldItems}
+                            githubName={mentorGitHubName}
                             timeZone={timeZone}
                             country={countryName}
                           />

--- a/src/components/Mentor/Mentor.jsx
+++ b/src/components/Mentor/Mentor.jsx
@@ -55,7 +55,7 @@ const Mentor = () => {
             let mentorCountry = "";
             let mentorTimezone = "";
             for (let i = 0; i < 3; i++) {
-              switch(mentor.customFieldItems[i].idCustomField) {
+              switch (mentor.customFieldItems[i].idCustomField) {
                 case "5eb71b3551de3a59ce8d9bd8":
                   mentorGitHubName = mentor.customFieldItems[i].value.text;
                   break;
@@ -113,7 +113,12 @@ const Mentor = () => {
                         <p className="font-weight-bold">{mentor.name}</p>
 
                         <div className="mt-2">
-                          <img src={flagURL} height="30px" width="30px" alt="The flag of the mentor's home country"></img>
+                          <img
+                            src={flagURL}
+                            height="30px"
+                            width="30px"
+                            alt="The flag of the mentor's home country"
+                          ></img>
                           <span className="ml-3 font-weight-bold h4">
                             {countryName}
                           </span>

--- a/src/components/Mentor/Mentor.jsx
+++ b/src/components/Mentor/Mentor.jsx
@@ -70,7 +70,7 @@ const Mentor = () => {
               }
             }
             const flagURL =
-              "https://www.countryflagsapi.com/png/" + `${mentorCountry}`;
+              `https://flagcdn.com/w40/${mentorCountry.toLowerCase()}.png`;
 
             const timeZone = moment
               .tz(moment(), `${mentorTimezone}`)
@@ -115,8 +115,6 @@ const Mentor = () => {
                         <div className="mt-2">
                           <img
                             src={flagURL}
-                            height="30px"
-                            width="30px"
                             alt="The flag of the mentor's home country"
                           ></img>
                           <span className="ml-3 font-weight-bold h4">

--- a/src/components/MentorModal/MentorModal.jsx
+++ b/src/components/MentorModal/MentorModal.jsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
 import { Badge, Modal, ModalBody, ModalFooter } from "reactstrap";
 
-const MentorModal = ({ name, desc, tags, customInfo, timeZone, country }) => {
+const MentorModal = ({ name, desc, tags, githubName, timeZone, country }) => {
   const [modal, setModal] = useState(false);
   const toggle = () => setModal(!modal);
-  let githubURL =
-    "https://github.com/" + `${customInfo[2] && customInfo[2].value.text}`;
+  const githubURL = `https://github.com/${githubName}`;
 
   return (
     <div>
@@ -26,9 +25,9 @@ const MentorModal = ({ name, desc, tags, customInfo, timeZone, country }) => {
           <div className="h3">{desc}</div>
           <div className="mt-3 Modal-custominfo ">
             <span className="ml-3 Modal-customFiled">
-              Github:{" "}
+              {`Github: `}
               <a href={githubURL}>
-                @{customInfo[2] && customInfo[2].value.text}
+                {`@${githubName}`}
               </a>
             </span>
             <br />

--- a/src/components/MentorModal/MentorModal.jsx
+++ b/src/components/MentorModal/MentorModal.jsx
@@ -26,9 +26,7 @@ const MentorModal = ({ name, desc, tags, githubName, timeZone, country }) => {
           <div className="mt-3 Modal-custominfo ">
             <span className="ml-3 Modal-customFiled">
               {`Github: `}
-              <a href={githubURL}>
-                {`@${githubName}`}
-              </a>
+              <a href={githubURL}>{`@${githubName}`}</a>
             </span>
             <br />
             <span className="ml-3 Modal-customFiled">Country: {country}</span>


### PR DESCRIPTION
### Bug

When requesting mentor cards from the [Trello API](https://api.trello.com/1/lists/5eb715b48caa18614425c25e/cards?fields=name,labels,cover,desc&customFields=true&customFieldItems=true&attachments=true&attachment_fields=all), the custom fields including GitHub name, country, and timezone, are returned in random order.
In `Mentor.jsx` (and passed on to `MentorModal.jsx`), the logic is not hardened against this but instead access the custom fields by index which can lead to incorrect values due to the random order.

### Solution

Identify custom fields of mentor cards requested from Trello API by `idCustomField` instead.

### Included changes

* identify custom fields by `idCustomField`
* pass only `mentorGithubName` to `MentorModal` (rename `customInfo` param to `githubName`)
* update country flag service url from "countryflags.io" to "countryflagsapi.com" and adjust path accordingly

### Outstanding before merging

Fix country flag integration.
The adjusted url contains the requested flag image, but somehow it's not properly integrated into the page.