### PR TITLE
fix: replace gatsby-plugin-react-helmet with Gatsby Head API

### DIFF
--- a/data/SiteConfig.js
+++ b/data/SiteConfig.js
@@ -1,6 +1,5 @@
 const config = {
-  siteTitle: "Terasology Project", // Site title.
-  siteTitleShort: "Terasology", // Short site title for homescreen (PWA). Preferably should be under 12 characters to prevent truncation.
+  siteTitle: "Terasology", // Site title. Same as Short site title for home screen (PWA). Preferably should be under 12 characters to prevent truncation.
   siteTitleAlt: "Terasology Project | An Open Source Voxel World", // Alternative site title for SEO.
   siteLogo: "/logos/logo.png", // Logo used for SEO and manifest.
   siteUrl: "https://terasology.org", // Domain of your website without pathPrefix.
@@ -8,7 +7,6 @@ const config = {
   siteDescription:
     "Terasology is a super extensible open source voxel-based game. Born from a Minecraft-inspired tech demo, it is gradually becoming a stable platform for all sorts of gameplay settings in a voxel world.", // Website description used for RSS feeds/meta description tag.
   siteRss: "/rss.xml", // Path to the RSS file.
-  siteFBAppID: "", // FB Application ID for using app insights
   googleAnalyticsID: "", // GA tracking ID.
   postDefaultCategoryID: "Update", // Default category for posts.
   dateFromFormat: "YYYY-MM-DD", // Date format used in the frontmatter.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -51,7 +51,6 @@ module.exports = {
         ]
       }
     },
-    "gatsby-plugin-react-helmet",
     "gatsby-plugin-sass",
     {
       resolve: "gatsby-source-filesystem",

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,7 +4,10 @@ const config = require("./data/SiteConfig");
 module.exports = {
   pathPrefix: config.pathPrefix === "" ? "/ModuleSite" : config.pathPrefix,
   siteMetadata: {
+    title: config.siteTitle,
     siteUrl: urljoin(config.siteUrl, config.pathPrefix),
+    twitterUsername: "@Terasology",
+    image: config.siteLogo,
     rssMetadata: {
       site_url: urljoin(config.siteUrl, config.pathPrefix),
       feed_url: urljoin(config.siteUrl, config.pathPrefix, config.siteRss),
@@ -91,7 +94,7 @@ module.exports = {
       resolve: "gatsby-plugin-manifest",
       options: {
         name: config.siteTitle,
-        short_name: config.siteTitleShort,
+        short_name: config.siteTitle,
         description: config.siteDescription,
         start_url: config.pathPrefix === "" ? "/" : config.pathPrefix,
         background_color: config.backgroundColor,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "gatsby-plugin-manifest": "^4.0.0",
     "gatsby-plugin-nprogress": "^4.0.0",
     "gatsby-plugin-offline": "^5.0.0",
-    "gatsby-plugin-react-helmet": "^5.0.0",
     "gatsby-plugin-sass": "^5.0.0",
     "gatsby-plugin-sharp": "^4.0.0",
     "gatsby-plugin-sitemap": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bootstrap": "^4.3.1",
     "canvas": "^2.8.0",
-    "gatsby": "^4.0.0",
+    "gatsby": "^4.19.0",
     "gatsby-background-image": "^1.5.3",
     "gatsby-image": "^3.7.1",
     "gatsby-plugin-catch-links": "^4.0.0",

--- a/src/components/Mentor/Mentor.jsx
+++ b/src/components/Mentor/Mentor.jsx
@@ -31,7 +31,7 @@ const Mentor = () => {
   return (
     <Col lg="12">
       <div>
-        <h1 className="text-center">Mentor's</h1>
+        <h1 className="text-center">Mentors</h1>
         <div className="container my-4">
           <div className="home-underline"></div>
         </div>
@@ -43,7 +43,7 @@ const Mentor = () => {
             toggle={onDismiss}
           >
             <span className="alert-box">
-              Problem fetching Mentor's Information .(Error Code: {status})
+              Problem fetching mentor information. (Error Code: {status})
             </span>
           </Alert>
         </div>

--- a/src/components/SEO/SEO.jsx
+++ b/src/components/SEO/SEO.jsx
@@ -1,90 +1,39 @@
+import { useSiteMetadata } from "../../hooks/use-site-metadata";
 import React from "react";
-import Helmet from "react-helmet";
 import urljoin from "url-join";
-import config from "../../../data/SiteConfig";
 
-const SEO = ({ postNode, postPath, postSEO }) => {
-  let title;
-  let description;
-  let postURL;
-  if (postSEO) {
-    const postMeta = postNode.frontmatter;
-    ({ title } = postMeta);
-    description = postMeta.description
-      ? postMeta.description
-      : postNode.excerpt;
-    postURL = urljoin(config.siteUrl, config.pathPrefix, postPath);
-  } else {
-    title = config.siteTitle;
-    description = config.siteDescription;
-  }
+const SEO = ({ title, description, pathname, children }) => {
+  const {
+    title: defaultTitle,
+    description: defaultDescription,
+    siteUrl,
+    image,
+    twitterUsername
+  } = useSiteMetadata();
 
-  const blogURL = urljoin(config.siteUrl, config.pathPrefix);
-  const schemaOrgJSONLD = [
-    {
-      "@context": "http://schema.org",
-      "@type": "WebSite",
-      url: blogURL,
-      name: title,
-      alternateName: config.siteTitleAlt ? config.siteTitleAlt : ""
-    }
-  ];
-  if (postSEO) {
-    schemaOrgJSONLD.push(
-      {
-        "@context": "http://schema.org",
-        "@type": "BreadcrumbList",
-        itemListElement: [
-          {
-            "@type": "ListItem",
-            position: 1,
-            item: {
-              "@id": postURL,
-              name: title
-            }
-          }
-        ]
-      },
-      {
-        "@context": "http://schema.org",
-        "@type": "BlogPosting",
-        url: blogURL,
-        name: title,
-        alternateName: config.siteTitleAlt ? config.siteTitleAlt : "",
-        headline: title,
-        description
-      }
-    );
-  }
+  const seo = {
+    title: title || defaultTitle,
+    description: description || defaultDescription,
+    url: urljoin(siteUrl, pathname || ""),
+    image: urljoin(siteUrl, image),
+    twitterUsername
+  };
+
   return (
-    <Helmet>
-      {/* General tags */}
-      <meta name="description" content={description} />
-
-      {/* Schema.org tags */}
-      <script type="application/ld+json">
-        {JSON.stringify(schemaOrgJSONLD)}
-      </script>
-
-      {/* OpenGraph tags */}
-      <meta property="og:url" content={postSEO ? postURL : blogURL} />
-      {postSEO ? <meta property="og:type" content="article" /> : null}
-      <meta property="og:title" content={title} />
-      <meta property="og:description" content={description} />
-      <meta
-        property="fb:app_id"
-        content={config.siteFBAppID ? config.siteFBAppID : ""}
-      />
-
-      {/* Twitter Card tags */}
+    <>
+      <title>{seo.title}</title>
+      <meta name="description" content={seo.description} />
+      <meta property="og:url" content={seo.url} />
+      <meta property="og:title" content={seo.title} />
+      <meta property="og:description" content={seo.description} />
       <meta name="twitter:card" content="summary_large_image" />
-      <meta
-        name="twitter:creator"
-        content={config.userTwitter ? config.userTwitter : ""}
-      />
-      <meta name="twitter:title" content={title} />
-      <meta name="twitter:description" content={description} />
-    </Helmet>
+      <meta name="twitter:creator" content={seo.twitterUsername} />
+      <meta name="twitter:title" content={seo.title} />
+      <meta name="twitter:description" content={seo.description} />
+      <meta name="twitter:image" content={seo.image} />
+      <meta name="twitter.url" content={seo.url} />
+      {children}
+    </>
   );
 };
 

--- a/src/hooks/use-site-metadata.jsx
+++ b/src/hooks/use-site-metadata.jsx
@@ -1,0 +1,19 @@
+import { graphql, useStaticQuery } from "gatsby";
+
+export const useSiteMetadata = () => {
+  const data = useStaticQuery(graphql`
+    query {
+      site {
+        siteMetadata {
+          title
+          description
+          twitterUsername
+          image
+          siteUrl
+        }
+      }
+    }
+  `);
+
+  return data.site.siteMetadata;
+};

--- a/src/layout/index.jsx
+++ b/src/layout/index.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Helmet from "react-helmet";
 import { Container } from "reactstrap";
 import config from "../../data/SiteConfig";
 import Header from "../components/Header/Header";
@@ -12,10 +11,6 @@ import favicon from "../../static/logos/logo.png";
 // eslint-disable-next-line no-unused-vars
 const Layout = ({ children, location }) => (
   <body>
-    <Helmet>
-      <meta name="description" content={config.siteDescription} />
-      <link rel="icon shortcut" href={favicon} type="image/png" />
-    </Helmet>
     <Header />
     <Container className="main">{children}</Container>
     <Footer />
@@ -23,3 +18,10 @@ const Layout = ({ children, location }) => (
 );
 
 export default Layout;
+
+export const Head = () => (
+  <>
+    <meta name="description" content={config.siteDescription} />
+    <link rel="icon shortcut" href={favicon} type="image/png" />
+  </>
+);

--- a/src/pages/404.jsx
+++ b/src/pages/404.jsx
@@ -1,13 +1,10 @@
 import React from "react";
-import Helmet from "react-helmet";
 import Layout from "../layout";
 import config from "../../data/SiteConfig";
 
 const error404 = () => (
   <Layout>
-    <div className="about-container">
-      <Helmet title={`Not Found | ${config.siteTitle}`} />
-    </div>
+    <div className="about-container"></div>
     <center>
       <h1>404</h1>
       <h4>This is not the page you are looking for...</h4>
@@ -16,3 +13,9 @@ const error404 = () => (
 );
 
 export default error404;
+
+export const Head = () => (
+  <>
+    <title>{`Not Found | ${config.siteTitle}`}</title>
+  </>
+);

--- a/src/pages/downloads.jsx
+++ b/src/pages/downloads.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import Layout from "../layout";
 import Download from "../components/Download/Download";
+import config from "../../data/SiteConfig";
+import SEO from "../components/SEO/SEO";
 
 const download = () => (
   <Layout>
@@ -9,3 +11,5 @@ const download = () => (
 );
 
 export default download;
+
+export const Head = () => <SEO title={`Download | ${config.siteTitle}`} />;

--- a/src/pages/game.jsx
+++ b/src/pages/game.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Helmet from "react-helmet";
 import Layout from "../layout";
 import About from "../components/About/About";
 import config from "../../data/SiteConfig";
@@ -7,10 +6,15 @@ import config from "../../data/SiteConfig";
 const game = () => (
   <Layout>
     <div className="about-container">
-      <Helmet title={`The Game | ${config.siteTitle}`} />
       <About />
     </div>
   </Layout>
 );
 
 export default game;
+
+export const Head = () => (
+  <>
+    <title>{`The Game | ${config.siteTitle}`}</title>
+  </>
+);

--- a/src/pages/game.jsx
+++ b/src/pages/game.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Layout from "../layout";
 import About from "../components/About/About";
 import config from "../../data/SiteConfig";
+import SEO from "../components/SEO/SEO";
 
 const game = () => (
   <Layout>
@@ -13,8 +14,4 @@ const game = () => (
 
 export default game;
 
-export const Head = () => (
-  <>
-    <title>{`The Game | ${config.siteTitle}`}</title>
-  </>
-);
+export const Head = () => <SEO title={`The Game | ${config.siteTitle}`} />;

--- a/src/pages/gsoc_tsoc.jsx
+++ b/src/pages/gsoc_tsoc.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import Layout from "../layout";
 import GsocTsoc from "../components/GsocTsoc/GsocTsoc";
+import config from "../../data/SiteConfig";
+import SEO from "../components/SEO/SEO";
 
 const gsoc_tsoc = () => (
   <Layout>
@@ -9,3 +11,7 @@ const gsoc_tsoc = () => (
 );
 
 export default gsoc_tsoc;
+
+export const Head = () => (
+  <SEO title={`Student Programs | ${config.siteTitle}`} />
+);

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Helmet from "react-helmet";
 import Layout from "../layout";
 import config from "../../data/SiteConfig";
 import Index from "../components/Home/Index";
@@ -7,10 +6,15 @@ import Index from "../components/Home/Index";
 const index = () => (
   <Layout>
     <div className="about-container">
-      <Helmet title={`Home | ${config.siteTitle}`} />
       <Index />
     </div>
   </Layout>
 );
 
 export default index;
+
+export const Head = () => (
+  <>
+    <title>{`Home | ${config.siteTitle}`}</title>
+  </>
+);

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Layout from "../layout";
-import config from "../../data/SiteConfig";
+import SEO from "../components/SEO/SEO";
 import Index from "../components/Home/Index";
 
 const index = () => (
@@ -13,8 +13,4 @@ const index = () => (
 
 export default index;
 
-export const Head = () => (
-  <>
-    <title>{`Home | ${config.siteTitle}`}</title>
-  </>
-);
+export const Head = () => <SEO />;

--- a/src/pages/media.jsx
+++ b/src/pages/media.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Helmet from "react-helmet";
 import Layout from "../layout";
 import Media from "../components/Media/Media";
 import config from "../../data/SiteConfig";
@@ -7,10 +6,15 @@ import config from "../../data/SiteConfig";
 const media = () => (
   <Layout>
     <div className="media-container">
-      <Helmet title={`Media | ${config.siteTitle}`} />
       <Media />
     </div>
   </Layout>
 );
 
 export default media;
+
+export const Head = () => (
+  <>
+    <title>{`Media | ${config.siteTitle}`}</title>
+  </>
+);

--- a/src/pages/media.jsx
+++ b/src/pages/media.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Layout from "../layout";
 import Media from "../components/Media/Media";
 import config from "../../data/SiteConfig";
+import SEO from "../components/SEO/SEO";
 
 const media = () => (
   <Layout>
@@ -13,8 +14,4 @@ const media = () => (
 
 export default media;
 
-export const Head = () => (
-  <>
-    <title>{`Media | ${config.siteTitle}`}</title>
-  </>
-);
+export const Head = () => <SEO title={`Media | ${config.siteTitle}`} />;

--- a/src/pages/mentors.jsx
+++ b/src/pages/mentors.jsx
@@ -12,6 +12,4 @@ const mentors = () => (
 
 export default mentors;
 
-export const Head = () => (
-  <SEO title={`Mentors | ${config.siteTitle}`} />
-);
+export const Head = () => <SEO title={`Mentors | ${config.siteTitle}`} />;

--- a/src/pages/mentors.jsx
+++ b/src/pages/mentors.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import Layout from "../layout";
 import Mentor from "../components/Mentor/Mentor.jsx";
+import config from "../../data/SiteConfig";
+import SEO from "../components/SEO/SEO";
 
 const mentors = () => (
   <Layout>
@@ -9,3 +11,7 @@ const mentors = () => (
 );
 
 export default mentors;
+
+export const Head = () => (
+  <SEO title={`Mentors | ${config.siteTitle}`} />
+);

--- a/src/templates/blog.jsx
+++ b/src/templates/blog.jsx
@@ -72,7 +72,6 @@ const Blog = (
   return (
     <Layout>
       <div className="index-container">
-        <Helmet title={`Blog | ${config.siteTitle}`} />
         <SEO />
         <SearchForm
           query={searchQuery}
@@ -151,3 +150,9 @@ export const blogQuery = graphql`
 `;
 
 export default Blog;
+
+export const Head = () => (
+  <>
+    <title>{`Blog | ${config.siteTitle}`}</title>
+  </>
+);

--- a/src/templates/blog.jsx
+++ b/src/templates/blog.jsx
@@ -72,7 +72,6 @@ const Blog = (
   return (
     <Layout>
       <div className="index-container">
-        <SEO />
         <SearchForm
           query={searchQuery}
           tag={filterTag}
@@ -151,8 +150,4 @@ export const blogQuery = graphql`
 
 export default Blog;
 
-export const Head = () => (
-  <>
-    <title>{`Blog | ${config.siteTitle}`}</title>
-  </>
-);
+export const Head = () => <SEO title={`Blog | ${config.siteTitle}`} />;

--- a/src/templates/modulelist.jsx
+++ b/src/templates/modulelist.jsx
@@ -65,7 +65,6 @@ const Modulelist = (
   return (
     <Layout>
       <div className="index-container">
-        <SEO />
         <SearchForm query={searchQuery} filter={filterTag} />
         {isShown && (
           <SearchResults
@@ -141,8 +140,4 @@ export const moduleQuery = graphql`
 
 export default Modulelist;
 
-export const Head = () => (
-  <>
-    <title>{`Modules | ${config.siteTitle}`}</title>
-  </>
-);
+export const Head = () => <SEO title={`Modules | ${config.siteTitle}`} />;

--- a/src/templates/modulelist.jsx
+++ b/src/templates/modulelist.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import Helmet from "react-helmet";
 import { Link, graphql } from "gatsby";
 import Layout from "../layout";
 import PostListing from "../components/PostListing/PostListing";
@@ -66,7 +65,6 @@ const Modulelist = (
   return (
     <Layout>
       <div className="index-container">
-        <Helmet title={`Modules | ${config.siteTitle}`} />
         <SEO />
         <SearchForm query={searchQuery} filter={filterTag} />
         {isShown && (
@@ -142,3 +140,9 @@ export const moduleQuery = graphql`
 `;
 
 export default Modulelist;
+
+export const Head = () => (
+  <>
+    <title>{`Modules | ${config.siteTitle}`}</title>
+  </>
+);

--- a/src/templates/modules.jsx
+++ b/src/templates/modules.jsx
@@ -22,7 +22,6 @@ export default class ModuleTemplate extends React.Component {
     return (
       <Layout>
         <div>
-          <SEO postPath={slug} postNode={postNode} postSEO />
           <div>
             <GatsbyImage
               className={"post-cover"}
@@ -72,8 +71,9 @@ export const pageQuery = graphql`
   }
 `;
 
-export const Head = ({data}) => (
-  <>
-    <title>{`${data.markdownRemark.frontmatter.title} | ${config.siteTitle}`}</title>
-  </>
+export const Head = ({ data, pageContext }) => (
+  <SEO
+    pathname={pageContext.slug}
+    title={`${data.markdownRemark.frontmatter.title} | ${config.siteTitle}`}
+  />
 );

--- a/src/templates/modules.jsx
+++ b/src/templates/modules.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Helmet from "react-helmet";
 import { graphql } from "gatsby";
 import Layout from "../layout";
 import PostTags from "../components/PostTags/PostTags";
@@ -23,9 +22,6 @@ export default class ModuleTemplate extends React.Component {
     return (
       <Layout>
         <div>
-          <Helmet>
-            <title>{`${post.title} | ${config.siteTitle}`}</title>
-          </Helmet>
           <SEO postPath={slug} postNode={postNode} postSEO />
           <div>
             <GatsbyImage
@@ -75,3 +71,9 @@ export const pageQuery = graphql`
     }
   }
 `;
+
+export const Head = ({data}) => (
+  <>
+    <title>{`${data.markdownRemark.frontmatter.title} | ${config.siteTitle}`}</title>
+  </>
+);

--- a/src/templates/post.jsx
+++ b/src/templates/post.jsx
@@ -21,7 +21,6 @@ export default class PostTemplate extends React.Component {
     return (
       <Layout>
         <div>
-          <SEO postPath={slug} postNode={postNode} postSEO />
           <div>
             <div className={"title"}>
               <h1>{post.title}</h1>
@@ -78,8 +77,9 @@ export const pageQuery = graphql`
   }
 `;
 
-export const Head = ({ data }) => (
-  <>
-    <title>{`${data.markdownRemark.frontmatter.title} | ${config.siteTitle}`}</title>
-  </>
+export const Head = ({ data, pageContext }) => (
+  <SEO
+    pathname={pageContext.slug}
+    title={`${data.markdownRemark.frontmatter.title} | ${config.siteTitle}`}
+  />
 );

--- a/src/templates/post.jsx
+++ b/src/templates/post.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Helmet from "react-helmet";
 import { graphql } from "gatsby";
 import Layout from "../layout";
 import SocialLinks from "../components/SocialLinks/SocialLinks";
@@ -22,9 +21,6 @@ export default class PostTemplate extends React.Component {
     return (
       <Layout>
         <div>
-          <Helmet>
-            <title>{`${post.title} | ${config.siteTitle}`}</title>
-          </Helmet>
           <SEO postPath={slug} postNode={postNode} postSEO />
           <div>
             <div className={"title"}>
@@ -81,3 +77,9 @@ export const pageQuery = graphql`
     }
   }
 `;
+
+export const Head = ({ data }) => (
+  <>
+    <title>{`${data.markdownRemark.frontmatter.title} | ${config.siteTitle}`}</title>
+  </>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6721,13 +6721,6 @@ gatsby-plugin-page-creator@^4.25.0:
     globby "^11.1.0"
     lodash "^4.17.21"
 
-gatsby-plugin-react-helmet@^5.0.0:
-  version "5.25.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-5.25.0.tgz#6849d405bfbc0846e73449d4425b45f84ec58fbb"
-  integrity sha512-sU/xae/sGuYFcFDpqUxwXnaOmx8xrU2Q+XSULqAapji0uTBhW6al6CJsaPFigi8IOG2bQX8ano2iWWcGF3/GHw==
-  dependencies:
-    "@babel/runtime" "^7.15.4"
-
 gatsby-plugin-sass@^5.0.0:
   version "5.25.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-sass/-/gatsby-plugin-sass-5.25.0.tgz#8aedec8d58f50826c1c25faa52f94175e69b8017"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7066,7 +7066,7 @@ gatsby-worker@^1.25.0:
     "@babel/core" "^7.15.5"
     "@babel/runtime" "^7.15.4"
 
-gatsby@^4.0.0:
+gatsby@^4.19.0:
   version "4.25.1"
   resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-4.25.1.tgz#c737534fd3a97914ae469d59bd3e198fb634126d"
   integrity sha512-mCwvRfgFI/dFydn0JTS0ckOS7MAGeX0SgB06+UXO9PWJld/YaSldmQ7HYcoXRV1KvDyXmo0C0b0R/7WAoQhI8Q==


### PR DESCRIPTION
The [gatsby-plugin-react-helmet](https://www.gatsbyjs.com/plugins/gatsby-plugin-react-helmet/) will be deprecated (and already prints warnings during the build process) in favor of the [Gatsby Head API](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/).

In this PR, I replace all usages of `<Helmet>` with usages of the new API.

- build(deps): require at least gatsby v4.19.0 for gatsby-head support
- chore: replace Helmet with gatsby-head functionality
- fix: use SEO component everywhere, configure if necessary
- build(deps): remove 'gatsby-plugin-react-helmet'

#### Note

This is dropping some functionality around [JSON for Linking Data](https://json-ld.org/) which I don't fully understand.
The Gatsby docs mention this in [SEO Component > Additional Information](https://www.gatsbyjs.com/docs/how-to/adding-common-features/adding-seo-component/#additional-information), so we can probably add that easily back in (when we know what exactly to put where).
