### PR TITLE
fix: avoid infinite loop when showing search filters + some CSS fixes

### DIFF
--- a/src/components/BlogSearchForm/BlogSearchForm.jsx
+++ b/src/components/BlogSearchForm/BlogSearchForm.jsx
@@ -38,10 +38,9 @@ const SearchForm = ({ query, tag, author, date, location }) => {
             </Label>
             <Input
               type="search"
-              id="search-input"
               name="keywords"
               bsSize="lg"
-              className="form-control"
+              className="search-input form-control"
               aria-controls="search-results-count"
               onChange={(e) =>
                 navigate(
@@ -61,11 +60,11 @@ const SearchForm = ({ query, tag, author, date, location }) => {
           <Button
             type="button"
             color="primary"
+            className="search-btn"
+            size="lg"
             onClick={() => {
               setShowFilter(!showFilter);
             }}
-            size="lg"
-            id="search-btn"
           >
             <FaFilter />
             Filter
@@ -84,11 +83,10 @@ const SearchForm = ({ query, tag, author, date, location }) => {
 
                   <Input
                     type="select"
-                    name="author"
-                    id="search-tag"
+                    name="tags"
                     bsSize="lg"
                     aria-controls="search-results-count"
-                    className="option-position"
+                    className="search-filter option-position"
                     onChange={(e) =>
                       navigate(
                         `${
@@ -117,10 +115,9 @@ const SearchForm = ({ query, tag, author, date, location }) => {
                   <Input
                     type="select"
                     name="author"
-                    id="search-tag"
                     bsSize="lg"
                     aria-controls="search-results-count"
-                    className="option-position"
+                    className="search-filter option-position"
                     onChange={(e) =>
                       navigate(
                         `${location.pathname}?keywords=${query}&tag=${
@@ -146,11 +143,10 @@ const SearchForm = ({ query, tag, author, date, location }) => {
                   </Label>
                   <Input
                     type="date"
-                    name="author"
-                    id="search-tag"
+                    name="date"
                     bsSize="lg"
                     aria-controls="search-results-count"
-                    className="option-position"
+                    className="search-filter option-position"
                     onChange={(e) =>
                       navigate(
                         `${location.pathname}?keywords=${query}&tag=${
@@ -171,8 +167,8 @@ const SearchForm = ({ query, tag, author, date, location }) => {
                     type="button"
                     color="primary"
                     size="lg"
-                    id="search-btn"
-                    onClick={navigate(`${location.pathname}`)}
+                    className="search-btn"
+                    onClick={() => navigate(`${location.pathname}`)}
                   >
                     Reset
                   </Button>

--- a/src/components/SearchForm/SearchForm.jsx
+++ b/src/components/SearchForm/SearchForm.jsx
@@ -21,8 +21,8 @@ const SearchForm = ({ query, filter, location }) => {
             <Input
               type="select"
               name="filter"
-              id="search-tag"
               bsSize="lg"
+              className="search-filter"
               aria-controls="search-results-count"
               onChange={(e) =>
                 navigate(
@@ -49,7 +49,7 @@ const SearchForm = ({ query, filter, location }) => {
             </Label>
             <Input
               type="search"
-              id="search-input"
+              className="search-input"
               name="keywords"
               bsSize="lg"
               aria-controls="search-results-count"
@@ -66,7 +66,7 @@ const SearchForm = ({ query, filter, location }) => {
           </FormGroup>
         </Col>
         <Col md="2">
-          <Button type="submit" color="primary" size="lg" id="search-btn">
+          <Button type="submit" color="primary" size="lg" className="search-btn">
             Search
           </Button>
         </Col>

--- a/src/components/SearchForm/SearchForm.jsx
+++ b/src/components/SearchForm/SearchForm.jsx
@@ -66,7 +66,12 @@ const SearchForm = ({ query, filter, location }) => {
           </FormGroup>
         </Col>
         <Col md="2">
-          <Button type="submit" color="primary" size="lg" className="search-btn">
+          <Button
+            type="submit"
+            color="primary"
+            size="lg"
+            className="search-btn"
+          >
             Search
           </Button>
         </Col>

--- a/src/layout/css/_buttons.scss
+++ b/src/layout/css/_buttons.scss
@@ -42,7 +42,7 @@ a.btn-primary {
   border-radius: 5px;
 }
 
-#search-btn {
+.search-btn {
   margin-top: 31px;
   font-size: 1.75rem;
   width: 100%;
@@ -59,7 +59,7 @@ a.btn-primary {
 }
 
 @media screen and (max-width: 768px) {
-  #search-btn {
+  .search-btn {
     margin-top: 10px;
   }
 }

--- a/src/layout/css/_search.scss
+++ b/src/layout/css/_search.scss
@@ -3,8 +3,8 @@
   padding-bottom: 0px;
 }
 
-#search-input,
-#search-tag {
+.search-input,
+.search-filter {
   font-size: 1.75rem;
 }
 


### PR DESCRIPTION
The main issue was a missing `() => ...` which lead to immediate execution of the `navigate(...)` call of the "Reset" button.

Along the way, I've spotted and fixed a couple things along mixing `id` and `className` and how things are referenced in the CSS.
