### PR TITLE
fix: fix Windows launcher download link

### DIFF
--- a/src/components/Download/Download.jsx
+++ b/src/components/Download/Download.jsx
@@ -39,7 +39,7 @@ function Download() {
       let downloadUrl;
 
       if (platform === "Win32") {
-        downloadUrl = data.assets && data.assets[3].browser_download_url;
+        downloadUrl = data.assets && data.assets[2].browser_download_url;
         srcLoc.href = downloadUrl;
       } else if (platform === "Linux x86_64") {
         downloadUrl = data.assets && data.assets[0].browser_download_url;


### PR DESCRIPTION
This fixes the launcher downloads for Windows by changing the download index to 2, since there are only 3 downloads available. Indexes start from 0.

You can verify that the index for Windows is 2 by checking the API output directly at https://api.github.com/repos/MovingBlocks/TerasologyLauncher/releases/latest.