### PR TITLE
fix: broken links after engine wiki to docsify migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Our custom source plugin fetches information from GitHub, and therefore needs a 
 
 > 🧰 Access Tokens in CI
 >
-> If the token expires, you can follow the ["How to fix an expired GitHub Action token"](https://github.com/MovingBlocks/Terasology/wiki/Maintenance#how-to-fix-an-expired-github-action-token) instructions with the following adjustments:
+> If the token expires, you can follow the ["How to fix an expired GitHub Action token"](http://terasology.org/Terasology/#/Maintenance?id=how-to-fix-an-expired-github-action-token) instructions with the following adjustments:
 > * the token required for the custom source plugin does not require additional scopes, which means you can skip step 2
 > * steps 4 and 5 should be performed in the [repository settings for actions] and in the [repository settings for dependabot] on the respective `MODULE_FETCH_GITHUB_TOKEN` secrets
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Our custom source plugin fetches information from GitHub, and therefore needs a 
 
 > 🧰 Access Tokens in CI
 >
-> If the token expires, you can follow the ["How to fix an expired GitHub Action token"](http://terasology.org/Terasology/#/Maintenance?id=how-to-fix-an-expired-github-action-token) instructions with the following adjustments:
+> If the token expires, you can follow the ["How to fix an expired GitHub Action token"](https://terasology.org/Terasology/#/Maintenance?id=how-to-fix-an-expired-github-action-token) instructions with the following adjustments:
 > * the token required for the custom source plugin does not require additional scopes, which means you can skip step 2
 > * steps 4 and 5 should be performed in the [repository settings for actions] and in the [repository settings for dependabot] on the respective `MODULE_FETCH_GITHUB_TOKEN` secrets
 

--- a/blog/2021-03-20-terasaturday-12-whatever-floats-your-island/index.md
+++ b/blog/2021-03-20-terasaturday-12-whatever-floats-your-island/index.md
@@ -131,7 +131,7 @@ Let's end this post with a teaser for a TeraSpotlight post about our recent comm
 [aseprite]: https://www.aseprite.org/
 [terasology/flyingislands]: https://github.com/Terasology/FlyingIslands
 [terasology/fallingblocks]: https://github.com/Terasology/FallingBlocks
-[terasology wiki]: http://terasology.org/Terasology/#/
+[terasology wiki]: https://terasology.org/Terasology/#/
 [movingblocks/terasology]: https://github.com/MovingBlocks/Terasology
 [movingblocks/gestalt]: https://github.com/MovingBlocks/gestalt
 [movingblocks/teranui]: https://github.com/MovingBlocks/TeraNUI

--- a/blog/2021-03-20-terasaturday-12-whatever-floats-your-island/index.md
+++ b/blog/2021-03-20-terasaturday-12-whatever-floats-your-island/index.md
@@ -131,7 +131,7 @@ Let's end this post with a teaser for a TeraSpotlight post about our recent comm
 [aseprite]: https://www.aseprite.org/
 [terasology/flyingislands]: https://github.com/Terasology/FlyingIslands
 [terasology/fallingblocks]: https://github.com/Terasology/FallingBlocks
-[terasology wiki]: https://github.com/MovingBlocks/Terasology/wiki
+[terasology wiki]: http://terasology.org/Terasology/#/
 [movingblocks/terasology]: https://github.com/MovingBlocks/Terasology
 [movingblocks/gestalt]: https://github.com/MovingBlocks/gestalt
 [movingblocks/teranui]: https://github.com/MovingBlocks/TeraNUI

--- a/blog/2023-04-22-waking-up-from-hibernation/index.md
+++ b/blog/2023-04-22-waking-up-from-hibernation/index.md
@@ -29,7 +29,7 @@ It's not a hard task and I've done it uncountable times before, but not everybod
 To bring my Iota workspace up to speed I used the `groovyw` utility tool that is shipped with the engine repository.
 You can run it easily via the provided wrapper scripts, that is `./groovyw` on Linux or `./groovyw.bat` on Windows.
 It comes in handy to initialize a workspace with a specific set of modules, fetch additional modules, or update everything via git.
-Our [Contributor Quick Start Guide](https://github.com/MovingBlocks/Terasology/wiki/Contributor-Quick-Start#set-up-your-terasology-development-workspace) also references it for the initial setup.
+Our [Contributor Quick Start Guide](http://terasology.org/Terasology/#/Contributor-Quick-Start?id=set-up-your-terasology-development-workspace) also references it for the initial setup.
 
 But today I'm only interested in updating all my modules in the workspace.
 

--- a/blog/2023-04-22-waking-up-from-hibernation/index.md
+++ b/blog/2023-04-22-waking-up-from-hibernation/index.md
@@ -29,7 +29,7 @@ It's not a hard task and I've done it uncountable times before, but not everybod
 To bring my Iota workspace up to speed I used the `groovyw` utility tool that is shipped with the engine repository.
 You can run it easily via the provided wrapper scripts, that is `./groovyw` on Linux or `./groovyw.bat` on Windows.
 It comes in handy to initialize a workspace with a specific set of modules, fetch additional modules, or update everything via git.
-Our [Contributor Quick Start Guide](http://terasology.org/Terasology/#/Contributor-Quick-Start?id=set-up-your-terasology-development-workspace) also references it for the initial setup.
+Our [Contributor Quick Start Guide](https://terasology.org/Terasology/#/Contributor-Quick-Start?id=set-up-your-terasology-development-workspace) also references it for the initial setup.
 
 But today I'm only interested in updating all my modules in the workspace.
 

--- a/src/pages/contribute.jsx
+++ b/src/pages/contribute.jsx
@@ -135,7 +135,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="https://github.com/MovingBlocks/Terasology/wiki/Contributor-Quick-Start"
+                  href="http://terasology.org/Terasology/#/Contributor-Quick-Start"
                 >
                   Contributor Quick Start
                 </a>
@@ -143,7 +143,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="https://github.com/MovingBlocks/Terasology/wiki/Terasology's-Multi-Repo-Workspace"
+                  href="http://terasology.org/Terasology/#/Multi-Repo-Workspace"
                 >
                   Multi-Repo Workspace
                 </a>
@@ -175,7 +175,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="https://github.com/MovingBlocks/Terasology/wiki/Code-Conventions"
+                  href="http://terasology.org/Terasology/#/Code-Conventions"
                 >
                   Code Style Conventions
                 </a>
@@ -191,7 +191,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="https://github.com/MovingBlocks/Terasology/blob/develop/docs/CODE_OF_CONDUCT.md"
+                  href="https://github.com/MovingBlocks/Terasology/blob/develop/.github/CODE_OF_CONDUCT.md"
                 >
                   Code of Conduct
                 </a>
@@ -214,7 +214,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="https://github.com/MovingBlocks/Terasology/wiki/Entity-System-Architecture"
+                  href="http://terasology.org/Terasology/#/Entity-System-Architecture"
                 >
                   Entity Component System (ECS)
                 </a>
@@ -253,7 +253,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="https://github.com/MovingBlocks/Terasology/wiki/Developing-Modules"
+                  href="http://terasology.org/Terasology/#/Developing-Modules"
                 >
                   Developing Modules
                 </a>
@@ -261,7 +261,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="https://github.com/MovingBlocks/Terasology/wiki/Testing-Modules"
+                  href="http://terasology.org/Terasology/#/Testing-Modules"
                 >
                   Testing Modules
                 </a>
@@ -269,7 +269,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="https://github.com/MovingBlocks/Terasology/wiki/Module-Dependencies"
+                  href="http://terasology.org/Terasology/#/Module-Dependencies"
                 >
                   Module Dependencies
                 </a>
@@ -277,7 +277,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="https://github.com/Terasology/TutorialWorldGeneration/wiki"
+                  href="https://terasology.github.io/TutorialWorldGeneration/#/tutorial/"
                 >
                   World Generation Tutorial
                 </a>
@@ -310,7 +310,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="https://github.com/MovingBlocks/Terasology/wiki/Serialization-Overview"
+                  href="http://terasology.org/Terasology/#/Serialization-Overview"
                 >
                   Serialization
                 </a>

--- a/src/pages/contribute.jsx
+++ b/src/pages/contribute.jsx
@@ -135,7 +135,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="http://terasology.org/Terasology/#/Contributor-Quick-Start"
+                  href="https://terasology.org/Terasology/#/Contributor-Quick-Start"
                 >
                   Contributor Quick Start
                 </a>
@@ -143,7 +143,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="http://terasology.org/Terasology/#/Multi-Repo-Workspace"
+                  href="https://terasology.org/Terasology/#/Multi-Repo-Workspace"
                 >
                   Multi-Repo Workspace
                 </a>
@@ -175,7 +175,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="http://terasology.org/Terasology/#/Code-Conventions"
+                  href="https://terasology.org/Terasology/#/Code-Conventions"
                 >
                   Code Style Conventions
                 </a>
@@ -214,7 +214,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="http://terasology.org/Terasology/#/Entity-System-Architecture"
+                  href="https://terasology.org/Terasology/#/Entity-System-Architecture"
                 >
                   Entity Component System (ECS)
                 </a>
@@ -253,7 +253,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="http://terasology.org/Terasology/#/Developing-Modules"
+                  href="https://terasology.org/Terasology/#/Developing-Modules"
                 >
                   Developing Modules
                 </a>
@@ -261,7 +261,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="http://terasology.org/Terasology/#/Testing-Modules"
+                  href="https://terasology.org/Terasology/#/Testing-Modules"
                 >
                   Testing Modules
                 </a>
@@ -269,7 +269,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="http://terasology.org/Terasology/#/Module-Dependencies"
+                  href="https://terasology.org/Terasology/#/Module-Dependencies"
                 >
                   Module Dependencies
                 </a>
@@ -310,7 +310,7 @@ function GettingStarted({ data }) {
               <li>
                 <a
                   className="text-success"
-                  href="http://terasology.org/Terasology/#/Serialization-Overview"
+                  href="https://terasology.org/Terasology/#/Serialization-Overview"
                 >
                   Serialization
                 </a>


### PR DESCRIPTION
- broken links in "Contribute" page
- broken link in README
- broken links in blog posts