### PR TITLE
Revert "chore(deps): bump bootstrap from 4.6.2 to 5.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "The Terasology Foundation",
   "dependencies": {
     "@reach/router": "^1.3.4",
-    "bootstrap": "^5.0.0",
+    "bootstrap": "^4.3.1",
     "canvas": "^2.8.0",
     "gatsby": "^5.9.1",
     "gatsby-plugin-catch-links": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3955,10 +3955,10 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-bootstrap@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.0.0.tgz#97635ac0e0d6cb466700ebf0fd266bfabf352ed2"
-  integrity sha512-tmhPET9B9qCl8dCofvHeiIhi49iBt0EehmIsziZib65k1erBW1rHhj2s/2JsuQh5Pq+xz2E9bEbzp9B7xHG+VA==
+bootstrap@^4.3.1:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.2.tgz#8e0cd61611728a5bf65a3a2b8d6ff6c77d5d7479"
+  integrity sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==
 
 boxen@^5.1.2:
   version "5.1.2"


### PR DESCRIPTION
Reverts MovingBlocks/movingblocks.github.com#251

Bootstrap upgrade from 4.6.2 to 5.0.0 broke the module list pagination (see screenshot below)
Reverting the upgrade until we figure out the breaking change and make sure it doesn't break the pagination.

That's what the upgrade made it look like:
![image](https://github.com/user-attachments/assets/5a50a8c8-01bb-46e3-96d4-228e29e5c2de)

Should look like this instead:
![image](https://github.com/user-attachments/assets/487acec7-d60b-4ba7-8823-bbb4415c26e7)
